### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+before_install:
+  - docker pull koalaman/shellcheck:v0.5.0
+
+script:
+  - docker run -v $(pwd):/scripts koalaman/shellcheck:v0.5.0 /scripts/artifact-backup.sh
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - docker pull koalaman/shellcheck:v0.5.0
 
 script:
-  - docker run -v $(pwd):/scripts koalaman/shellcheck:v0.5.0 /scripts/artifact-backup.sh
+  - docker run --workdir=/scripts --volume $(pwd):/scripts koalaman/shellcheck:v0.5.0 -x /scripts/artifact-backup.sh
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Artifactory CIFS/SMB network backup
+[![Build Status](https://travis-ci.org/baxeno/artifactory-network-backup.svg?branch=master)](https://travis-ci.org/baxeno/artifactory-network-backup)
 
 Transfers Artifactory weekly backup from a Linux environment to a CIFS/SMB network share (Windows environment).
 The SMB/CIFS protocol is a standard file sharing protocol widely deployed on Microsoft Windows machines.

--- a/artifact-backup.sh
+++ b/artifact-backup.sh
@@ -37,6 +37,7 @@ CFG_FILE="live-cfg.sh"
 TMP_DIR_REGEX='.*/[0-9]\{8\}\.[0-9]\{6\}\.tmp$'
 BACKUP_DIR_REGEX='.*/[0-9]\{8\}\.[0-9]\{6\}'
 BACKUP_FILE_REGEX='.*/[0-9]\{8\}\.[0-9]\{6\}\.tar'
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 
 ################################################################################
@@ -118,16 +119,16 @@ cleanup_network_backups()
 if [ "$#" -eq 2 ]; then
   if [[ "$1" == "-test" ]]; then
     # shellcheck source=test/test-1-cfg.sh
-    source "test/test-$2-cfg.sh"
+    source "${SCRIPT_DIR}/test/test-$2-cfg.sh"
     TEST=1
   else
     echo "Usage: $0 -test <type>"
     exit 1
   fi
 else
-  if [ -s "${CFG_FILE}" ]; then
+  if [ -s "${SCRIPT_DIR}/${CFG_FILE}" ]; then
     # shellcheck source=template-cfg.sh
-    source "${CFG_FILE}"
+    source "${SCRIPT_DIR}/${CFG_FILE}"
   else
     echo "Error: Unable to load configuration file - ${CFG_FILE}"
     exit 1


### PR DESCRIPTION
ShellCheck v0.5.0 is run on `artifact-backup.sh` and status is shown repository front page using `README.md`.