### PR TITLE
Travis: self tests + shellcheck version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ services:
   - docker
 
 before_install:
-  - docker pull koalaman/shellcheck:v0.5.0
+  - docker pull koalaman/shellcheck:v0.6.0
 
 script:
-  - docker run --workdir=/scripts --volume $(pwd):/scripts koalaman/shellcheck:v0.5.0 -x /scripts/artifact-backup.sh
+  - docker run --workdir=/scripts --volume $(pwd):/scripts koalaman/shellcheck:v0.6.0 -a -x /scripts/artifact-backup.sh
+  - docker run --workdir=/scripts --volume $(pwd):/scripts koalaman/shellcheck:v0.6.0 -a -x /scripts/run_test.sh
   - ./run_test.sh
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 
 script:
   - docker run --workdir=/scripts --volume $(pwd):/scripts koalaman/shellcheck:v0.5.0 -x /scripts/artifact-backup.sh
+  - ./run_test.sh
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ The following items are considered interfaces of this component:
 
 You should be able to run `./run_test.sh` and validate that `artifact-backup.sh` is working on host machine without doing remote connections.
 
-TODO: #9 Run in Travis pipeline.
-
 **Documentation:**
 
 [Complete list of github markdown emoji markup](https://gist.github.com/rxaviers/7360908)


### PR DESCRIPTION
Pipeline improved by more shellcheck coverage and a new version.
run_test.sh is now also called.